### PR TITLE
tar_extract: only warn once about xattr ENOTSUP

### DIFF
--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -64,6 +64,13 @@ type TarExtractor struct {
 	// to a trie if necessary). These paths are relative to the tar root but
 	// are fully symlink-expanded so no need to worry about that line noise.
 	upperPaths map[string]struct{}
+
+	// enotsupWarned is a flag set when we encounter the first ENOTSUP error
+	// dealing with xattrs. This is used to ensure extraction to a destination
+	// file system that does not support xattrs raises a single warning, rather
+	// than a warning for every file, which can amount to 1000s of messages that
+	// scroll a terminal, and may obscure other more important warnings.
+	enotsupWarned bool
 }
 
 // NewTarExtractor creates a new TarExtractor.
@@ -78,6 +85,7 @@ func NewTarExtractor(opt MapOptions) *TarExtractor {
 		partialRootless: opt.Rootless || inUserNamespace,
 		fsEval:          fsEval,
 		upperPaths:      make(map[string]struct{}),
+		enotsupWarned:   false,
 	}
 }
 
@@ -136,7 +144,11 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 		if errors.Cause(err) != unix.ENOTSUP {
 			return errors.Wrapf(err, "clear xattr metadata: %s", path)
 		}
-		log.Warnf("xattr{%s} ignoring ENOTSUP on clearxattrs", path)
+		if !te.enotsupWarned {
+			log.Warnf("xattr{%s} ignoring ENOTSUP on clearxattrs", path)
+			log.Warnf("xattr{%s} destination filesystem does not support xattrs, further warnings will be suppressed", path)
+			te.enotsupWarned = true
+		}
 	}
 
 	for name, value := range hdr.Xattrs {
@@ -178,7 +190,11 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 			// that extended attributes are simply unsupported by the
 			// underlying filesystem (such as AUFS or NFS).
 			if errors.Cause(err) == unix.ENOTSUP {
-				log.Warnf("xattr{%s} ignoring ENOTSUP on setxattr %q", hdr.Name, name)
+				if !te.enotsupWarned {
+					log.Warnf("xattr{%s} ignoring ENOTSUP on setxattr %q", hdr.Name, name)
+					log.Warnf("xattr{%s} destination filesystem does not support xattrs, further warnings will be suppressed", path)
+					te.enotsupWarned = true
+				}
 				continue
 			}
 			return errors.Wrapf(err, "restore xattr metadata: %s", path)
@@ -310,7 +326,11 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 			if errors.Cause(err) != unix.ENOTSUP {
 				return errors.Wrap(err, "get dirHdr.Xattrs")
 			}
-			log.Warnf("xattr{%s} ignoring ENOTSUP on llistxattr", dir)
+			if !te.enotsupWarned {
+				log.Warnf("xattr{%s} ignoring ENOTSUP on llistxattr", dir)
+				log.Warnf("xattr{%s} destination filesystem does not support xattrs, further warnings will be suppressed", path)
+				te.enotsupWarned = true
+			}
 		}
 		if len(xattrs) > 0 {
 			dirHdr.Xattrs = map[string]string{}


### PR DESCRIPTION
When a destination filesystem does not support xattrs we are rasing at
least 1 ENOTSUP related warning per file. This is unhelpful, and can
scroll the terminal obscuring more important warnings. Instead, show a
single warning for the first occurrence, with an improved explanation of
the cause.

This is to fix the Singularity issue: https://github.com/sylabs/singularity/issues/4662

I will attempt to upstream the PR to the upstream umoci, also.